### PR TITLE
unexpected action sheet dismissing in portrait mode only

### DIFF
--- a/Pickers/AbstractActionSheetPicker.m
+++ b/Pickers/AbstractActionSheetPicker.m
@@ -439,7 +439,12 @@ CG_INLINE BOOL isIPhone4()
 
 - (void) didRotate:(NSNotification *)notification
 {
-    [self dismissPicker];
+    NSUInteger supportedInterfaceOrientations = [[UIApplication sharedApplication]
+                                                 supportedInterfaceOrientationsForWindow:
+                                                 [UIApplication sharedApplication].keyWindow];
+    
+    if (supportedInterfaceOrientations != UIInterfaceOrientationMaskPortrait)
+        [self dismissPicker];
 }
 
 - (void)presentActionSheet:(SWActionSheet *)actionSheet


### PR DESCRIPTION
currently if my application support only portrait mode and I rotate the device, picker is dismissing unexpectedly
