### PR TITLE
Fix for UIDatePickerModeCountDownTimer callback

### DIFF
--- a/Pickers/ActionSheetDatePicker.m
+++ b/Pickers/ActionSheetDatePicker.m
@@ -61,6 +61,7 @@
         self.title = title;
         self.datePickerMode = datePickerMode;
         self.selectedDate = selectedDate;
+        self.duration = 60;
     }
     return self;
 }


### PR DESCRIPTION
If presenting an ActionSheetDatePicker with a datePickerMode of
UIDatePickerModeCountDownTimer, currently returns the current date in
the callback.

In this instance, would be much better to return the duration as that
is what the user is picking, not a date
