### PR TITLE
Add UITapGestureRecognizer on the SWActionSheet to allow dismissal

### DIFF
--- a/Pickers/SWActionSheet.m
+++ b/Pickers/SWActionSheet.m
@@ -102,8 +102,17 @@ static const enum UIViewAnimationOptions options = UIViewAnimationOptionCurveEas
         _bgView.backgroundColor = [UIColor whiteColor];
         [self addSubview:_bgView];
         [self addSubview:view];
+        UITapGestureRecognizer * backgroundTapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissActionSheet:)];
+        [self addGestureRecognizer:backgroundTapRecognizer];
     }
     return self;
+}
+
+- (void) dismissActionSheet:(UITapGestureRecognizer*) sender {
+    UIView *tappedView = [view hitTest:[sender locationInView:view] withEvent:nil];
+    if (self && self.presented && tappedView == nil) {
+        [self dismissWithClickedButtonIndex:0 animated:YES];
+    }
 }
 
 - (void)configureFrameForBounds:(CGRect)bounds


### PR DESCRIPTION
Add UITapGestureRecognizer on the SWActionSheet to allow tracking of taps. This also permits dismissing the action sheet when clicking on the background. The check for which view has been clicked is pretty rudimentary, so I would be interested if someone can come up with something better. Closes #80
