### PR TITLE
Fixed an issue when initial selections applied to picker with different number of rows for different components.

### DIFF
--- a/Pickers/ActionSheetCustomPicker.m
+++ b/Pickers/ActionSheetCustomPicker.m
@@ -81,8 +81,12 @@
             NSInteger row = [(NSNumber *) self.initialSelections[i] integerValue];
             NSAssert([pv numberOfRowsInComponent:i] > row, @"Number of sections not match");
             [pv selectRow:row inComponent:i animated:NO];
-            
-            [_delegate pickerView:pv didSelectRow:row inComponent:i];
+            // Strangely, the above selectRow:inComponent:animated: will not call 
+            // pickerView:didSelectRow:inComponent: automatically, so we manually call it.
+            if ( [_delegate respondsToSelector:@selector(pickerView:didSelectRow:inComponent:)] )
+            {
+                [_delegate pickerView:pv didSelectRow:row inComponent:i];
+            }
         }
 
     }

--- a/Pickers/ActionSheetCustomPicker.m
+++ b/Pickers/ActionSheetCustomPicker.m
@@ -81,6 +81,8 @@
             NSInteger row = [(NSNumber *) self.initialSelections[i] integerValue];
             NSAssert([pv numberOfRowsInComponent:i] > row, @"Number of sections not match");
             [pv selectRow:row inComponent:i animated:NO];
+            
+            [_delegate pickerView:pv didSelectRow:row inComponent:i];
         }
 
     }


### PR DESCRIPTION
### Scenario

For example, the titles for two pickerView components are like this: 

```objc
self.titles = @[ @[ @"Component 0 Row 0", @"Component 0 Row 1"],
                 @[ @"Component 0 Row 1", @"Component 1 Row 1", @"Component 1 Row 2", @"Component 1 Row 3"]
                ];
```

If the initial selections for pickerview are `@[@(0), @(0)]`, there is no problem. But when initial selections are `@[@(1), @(2)]`, there will be an app crash due to `
            NSAssert([pv numberOfRowsInComponent:i] > row, @"Number of sections not match");` in `- configuredPickerView`.

### Reason

I'm not very sure of the actual reason, but likely the reason is: set selected index for picker will not automatically call this `UIPickerView` delegate `- pickerView:didSelectRow:inComponent:`. In our case, we have different number of rows in different components, and we have to update the second component when selection is changed in the first component, before we set the second selection. If not, we will crash the app if the selection is beyond the range of rows in first selection in our case.


### Solution

A manual call to `- pickerView:didSelectRow:inComponent:` delegate will fix the problem. 