### PR TITLE
Fixes a crash while closing when using the Classy framework for styling

### DIFF
--- a/Pickers/SWActionSheet.m
+++ b/Pickers/SWActionSheet.m
@@ -73,6 +73,7 @@ static const enum UIViewAnimationOptions options = UIViewAnimationOptionCurveEas
         SWActionSheetWindow.hidden = YES;
         if ([SWActionSheetWindow isKeyWindow])
             [SWActionSheetWindow resignFirstResponder];
+        SWActionSheetWindow.rootViewController = nil;
         SWActionSheetWindow = nil;
     }
 }


### PR DESCRIPTION
The crash happens when the action sheet is going to close. More details about Classy at http://classy.as/