### PR TITLE
Added "tag" to AbstractActionSheet

### DIFF
--- a/Pickers/AbstractActionSheetPicker.h
+++ b/Pickers/AbstractActionSheetPicker.h
@@ -61,6 +61,7 @@ static NSString *const kActionType    = @"buttonAction";
 static NSString *const kActionTarget  = @"buttonActionTarget";
 
 @interface AbstractActionSheetPicker : NSObject<UIPopoverControllerDelegate>
+@property (nonatomic, assign) NSInteger tag;
 @property (nonatomic, strong) UIToolbar* toolbar;
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, strong) UIView *pickerView;


### PR DESCRIPTION
Added a tag property to AbstractActionSheetPicker for cases when there is a need to handle multiple pickers in one View Controller.