### PR TITLE
Keep app's interface orientation rules

### DIFF
--- a/Pickers/SWActionSheet.m
+++ b/Pickers/SWActionSheet.m
@@ -218,8 +218,4 @@ static const enum UIViewAnimationOptions options = UIViewAnimationOptionCurveEas
     return YES;
 }
 
--(UIInterfaceOrientationMask)supportedInterfaceOrientations{
-    return UIInterfaceOrientationMaskAll;
-}
-
 @end


### PR DESCRIPTION
In order to fix #100, removing these lines will:

- Let the picker in position if the picker receive a rotation event, but the application doesn't "answer" to it
- Dismiss the picker if the application can rotate, and receive a rotation event

I think it will be even better to let the picker rotates instead of dismissing (when it can rotate), but it's a deeper work, could be another PR!

Anyway, I think, that will be improve a bit this issue, even if it doesn't close it completely. I'm just not sure about the behaviour for iOS6? I test it on 7/8/9, looks good.