### PR TITLE
Fix Swift Bug RE self.initialSelection in multi-pickers

### DIFF
--- a/Pickers/ActionSheetMultipleStringPicker.m
+++ b/Pickers/ActionSheetMultipleStringPicker.m
@@ -32,7 +32,7 @@
 
 @interface ActionSheetMultipleStringPicker()
 @property (nonatomic,strong) NSArray *data; //Array of string arrays :)
-@property (nonatomic,assign) NSArray *initialSelection;
+@property (nonatomic,strong) NSArray *initialSelection;
 @end
 
 @implementation ActionSheetMultipleStringPicker

--- a/Pickers/ActionSheetStringPicker.m
+++ b/Pickers/ActionSheetStringPicker.m
@@ -29,7 +29,7 @@
 
 @interface ActionSheetStringPicker()
 @property (nonatomic,strong) NSArray *data;
-@property (nonatomic,assign) NSInteger selectedIndex;
+@property (nonatomic,strong) NSInteger selectedIndex;
 @end
 
 @implementation ActionSheetStringPicker

--- a/Pickers/ActionSheetStringPicker.m
+++ b/Pickers/ActionSheetStringPicker.m
@@ -29,7 +29,7 @@
 
 @interface ActionSheetStringPicker()
 @property (nonatomic,strong) NSArray *data;
-@property (nonatomic,retain) NSInteger selectedIndex;
+@property (nonatomic,assign) NSInteger selectedIndex;
 @end
 
 @implementation ActionSheetStringPicker

--- a/Pickers/ActionSheetStringPicker.m
+++ b/Pickers/ActionSheetStringPicker.m
@@ -29,7 +29,7 @@
 
 @interface ActionSheetStringPicker()
 @property (nonatomic,strong) NSArray *data;
-@property (nonatomic,strong) NSInteger selectedIndex;
+@property (nonatomic,retain) NSInteger selectedIndex;
 @end
 
 @implementation ActionSheetStringPicker


### PR DESCRIPTION
Affected file: ActionSheetMultipleStringPicker.m
Affected variable: self.initialSelection - marked as (nonatomic, assign) NSArray *

Issue: In a Swift project, when I create an instance with:
`let multiPicker = ActionSheetMultipleStringPicker(title: "", rows: [["Test"], ["Test"]], initialSelection: [0,0], doneBlock: nil, cancelBlock: nil, origin: self)`

The result is a crash with message EXC_BAD_ACCESS when ActionSheetMultipleStringPicker.m attempts to access self.initialSelection and enumerate through it.

Resolution: Change assign -> strong for self.initialSelection

This resolves the issue.