### PR TITLE
Adding the ability to disable popover behavior on iPad per picker instance

### DIFF
--- a/Pickers/AbstractActionSheetPicker.h
+++ b/Pickers/AbstractActionSheetPicker.h
@@ -81,6 +81,7 @@ static NSString *const kActionTarget  = @"buttonActionTarget";
 @property (nonatomic, retain) Class popoverBackgroundViewClass; //allow popover customization on iPad
 @property (nonatomic) UIInterfaceOrientationMask supportedInterfaceOrientations; // You can set your own supportedInterfaceOrientations value to prevent dismissing picker in some special cases.
 @property (nonatomic) TapAction tapDismissAction; // Specify, which action should be fired in case of tapping outside of the picker (on top darkened side). Default is TapActionNone.
+@property (nonatomic) BOOL popoverDisabled; // Disable popover behavior on iPad
 
 // For subclasses.
 - (instancetype)initWithTarget:(id)target successAction:(SEL)successAction cancelAction:(SEL)cancelActionOrNil origin:(id)origin;

--- a/Pickers/AbstractActionSheetPicker.m
+++ b/Pickers/AbstractActionSheetPicker.m
@@ -134,6 +134,7 @@ CG_INLINE BOOL isIPhone4() {
     if (self) {
         self.presentFromRect = CGRectZero;
         self.popoverBackgroundViewClass = nil;
+        self.popoverDisabled = NO;
 
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "UnavailableInDeploymentTarget"
@@ -260,7 +261,7 @@ CG_INLINE BOOL isIPhone4() {
     }
     [masterView addSubview:_pickerView];
 
-    if (![MyPopoverController canShowPopover] && !self.pickerBackgroundColor && [self.pickerBlurRadius intValue] > 0) {
+    if ((![MyPopoverController canShowPopover] || self.popoverDisabled) && !self.pickerBackgroundColor && [self.pickerBlurRadius intValue] > 0) {
         [self blurPickerBackground];
     } else {
         [self presentPickerForView:masterView];
@@ -611,7 +612,7 @@ CG_INLINE BOOL isIPhone4() {
 
 - (CGSize)viewSize {
     if (IS_IPAD) {
-        if ([MyPopoverController canShowPopover])
+        if (!self.popoverDisabled && [MyPopoverController canShowPopover])
             return CGSizeMake(320, 320);
         return [UIApplication sharedApplication].keyWindow.bounds.size;
     }
@@ -657,7 +658,7 @@ CG_INLINE BOOL isIPhone4() {
 - (void)presentPickerForView:(UIView *)aView {
     self.presentFromRect = aView.frame;
 
-    if ([MyPopoverController canShowPopover])
+    if (!self.popoverDisabled && [MyPopoverController canShowPopover])
         [self configureAndPresentPopoverForView:aView];
     else
         [self configureAndPresentActionSheetForView:aView];


### PR DESCRIPTION
I needed the ability to disable the iPad popover behavior (so that the picker shows full-width at the bottom of the screen), so I added it. This PR is in case you'd like to add it to the base fork.

I'm willing to work on the implementation if you have suggestions or requests. If you don't want it, no worries :)