### PR TITLE
Fix podspec

### DIFF
--- a/ActionSheetPicker-3.0.podspec
+++ b/ActionSheetPicker-3.0.podspec
@@ -1,15 +1,8 @@
 Pod::Spec.new do |spec|
 
-  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   spec.name = 'ActionSheetPicker-3.0'
   spec.version = '2.4.0'
   spec.summary = 'Easily present an ActionSheet with a PickerView, allowing the user to select from a number of immutable options.'
-
-  # This description is used to generate tags and improve search results.
-  #   * Think: What does it do? Why did you write it? What is the focus?
-  #   * Try to keep it short, snappy and to the point.
-  #   * Write the description between the DESC delimiters below.
-  #   * Finally, don't worry about the indent, CocoaPods strips it!
   spec.description  = <<-DESC
  Better version of ActionSheetPicker with support iOS7 and other improvements:
    - Spawn pickers with convenience function - delegate or reference not required. Just provide a target/action callback.
@@ -23,33 +16,14 @@ Pod::Spec.new do |spec|
                          "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/distance.png",
                          "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/ipad.png",
                          "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/string.png"]
-
-
-  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-
   spec.license = 'BSD'
-
-
-  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Specify the authors of the library, with email addresses. Email addresses
-  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
-  #  accepts just a name if you'd rather not provide an email address.
-  #
-  #  Specify a social_media_url where others can refer to, for example a twitter
-  #  profile URL.
-  #
-
   spec.authors = {
     'Petr Korolev' => 'https://github.com/skywinder',
     'Tim Cinel' => 'email@timcinel.com'
   }
-
   spec.social_media_url   = "https://twitter.com/skywinder/"
-
-  spec.platform     = :ios, "5.0"
+  spec.platform     = :ios, "6.1"
   spec.source = { :git => 'https://github.com/skywinder/ActionSheetPicker-3.0.git', :tag => "#{spec.version}" }
-
   spec.source_files = 'ActionSheetPicker.h', 'Pickers/*.{h,m}'
   spec.public_header_files = 'ActionSheetPicker.h', 'Pickers/*.h'
   spec.framework = 'UIKit'

--- a/ActionSheetPicker-3.0.podspec
+++ b/ActionSheetPicker-3.0.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do | s |
                         "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/ipad.png",
                         "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/string.png"]
     s.requires_arc = true
-    s.ios.deployment_target = '6.1'
+    s.platform = :ios, '6.1'
     s.public_header_files = 'ActionSheetPicker.h', 'Pickers/*.h'
     s.source_files = 'ActionSheetPicker.h', 'Pickers/*.{h,m}'
     s.framework = 'UIKit'

--- a/ActionSheetPicker-3.0.podspec
+++ b/ActionSheetPicker-3.0.podspec
@@ -1,23 +1,9 @@
-#
-#  Be sure to run `pod spec lint Peanut.podspec' to ensure this is a
-#  valid spec and to remove all comments including this before submitting the spec.
-#
-#  To learn more about Podspec attributes see https://guides.cocoapods.org/syntax/podspec.html
-#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
-#
-
 Pod::Spec.new do |spec|
 
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  These will help people to find your library, and whilst it
-  #  can feel like a chore to fill in it's definitely to your advantage. The
-  #  summary should be tweet-length, and the description more in depth.
-  #
-
-    spec.name = 'ActionSheetPicker-3.0'
-    spec.version = '2.4.0'
-    spec.summary = 'Easily present an ActionSheet with a PickerView, allowing the user to select from a number of immutable options.'
+  spec.name = 'ActionSheetPicker-3.0'
+  spec.version = '2.4.0'
+  spec.summary = 'Easily present an ActionSheet with a PickerView, allowing the user to select from a number of immutable options.'
 
   # This description is used to generate tags and improve search results.
   #   * Think: What does it do? Why did you write it? What is the focus?
@@ -32,21 +18,16 @@ Pod::Spec.new do |spec|
    - Universal (iPhone/iPod/iPad)
   DESC
 
-    spec.homepage = 'https://github.com/skywinder/ActionSheetPicker-3.0'
-    spec.screenshots   = [ "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/date.png",
-                        "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/distance.png",
-                        "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/ipad.png",
-                        "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/string.png"]
+  spec.homepage = 'https://github.com/skywinder/ActionSheetPicker-3.0'
+  spec.screenshots   = [ "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/date.png",
+                         "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/distance.png",
+                         "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/ipad.png",
+                         "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/string.png"]
 
 
   # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Licensing your code is important. See https://choosealicense.com for more info.
-  #  CocoaPods will detect a license file if there is a named LICENSE*
-  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
-  #
 
-    spec.license = 'BSD'
+  spec.license = 'BSD'
 
 
   # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -59,87 +40,18 @@ Pod::Spec.new do |spec|
   #  profile URL.
   #
 
-    spec.authors = {
-        'Petr Korolev' => 'https://github.com/skywinder',
-        'Tim Cinel' => 'email@timcinel.com'
-    }
+  spec.authors = {
+    'Petr Korolev' => 'https://github.com/skywinder',
+    'Tim Cinel' => 'email@timcinel.com'
+  }
 
-   spec.social_media_url   = "https://twitter.com/skywinder/"
+  spec.social_media_url   = "https://twitter.com/skywinder/"
 
-  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  If this Pod runs only on iOS or OS X, then specify the platform and
-  #  the deployment target. You can optionally include the target after the platform.
-  #
-
-   spec.platform     = :ios, "5.0"
-
-  #  When using multiple platforms
-  # spec.ios.deployment_target = "5.0"
-  # spec.osx.deployment_target = "10.7"
-  # spec.watchos.deployment_target = "2.0"
-  # spec.tvos.deployment_target = "9.0"
-
-
-  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Specify the location from where the source should be retrieved.
-  #  Supports git, hg, bzr, svn and HTTP.
-  #
-
-
-    spec.source = { :git => 'https://github.com/skywinder/ActionSheetPicker-3.0.git', :tag => "#{spec.version}" }
-
-
-  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  CocoaPods is smart about how it includes source code. For source files
-  #  giving a folder will include any swift, h, m, mm, c & cpp files.
-  #  For header files it will include any header in the folder.
-  #  Not including the public_header_files will make all headers public.
-  #
+  spec.platform     = :ios, "5.0"
+  spec.source = { :git => 'https://github.com/skywinder/ActionSheetPicker-3.0.git', :tag => "#{spec.version}" }
 
   spec.source_files = 'ActionSheetPicker.h', 'Pickers/*.{h,m}'
   spec.public_header_files = 'ActionSheetPicker.h', 'Pickers/*.h'
-
-
-  # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  A list of resources included with the Pod. These are copied into the
-  #  target bundle with a build phase script. Anything else will be cleaned.
-  #  You can preserve files from being cleaned, please don't preserve
-  #  non-essential files like tests, examples and documentation.
-  #
-
-  # spec.resource  = "icon.png"
-  # spec.resources = "Resources/*.png"
-
-  # spec.preserve_paths = "FilesToSave", "MoreFilesToSave"
-
-
-  # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Link your library with frameworks, or libraries. Libraries do not include
-  #  the lib prefix of their name.
-  #
-
-  
-    spec.framework = 'UIKit'
-  # spec.frameworks = "SomeFramework", "AnotherFramework"
-
-  # spec.library   = "iconv"
-  # spec.libraries = "iconv", "xml2"
-
-
-  # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  If your library depends on compiler flags you can set them in the xcconfig hash
-  #  where they will only apply to your library. If you depend on other Podspecs
-  #  you can include multiple dependencies to ensure it works.
-
-   spec.requires_arc = true
-
-  # spec.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
-  # spec.dependency "JSONKit", "~> 1.4"
-
+  spec.framework = 'UIKit'
+  spec.requires_arc = true
 end

--- a/ActionSheetPicker-3.0.podspec
+++ b/ActionSheetPicker-3.0.podspec
@@ -15,7 +15,6 @@ Pod::Spec.new do | s |
                         "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/string.png"]
     s.requires_arc = true
     s.ios.deployment_target = '6.1'
-    s.platform = :ios
     s.public_header_files = 'ActionSheetPicker.h', 'Pickers/*.h'
     s.source_files = 'ActionSheetPicker.h', 'Pickers/*.{h,m}'
     s.framework = 'UIKit'

--- a/ActionSheetPicker-3.0.podspec
+++ b/ActionSheetPicker-3.0.podspec
@@ -1,21 +1,145 @@
-Pod::Spec.new do | s |
-    s.name = 'ActionSheetPicker-3.0'
-    s.version = '2.4.0'
-    s.summary = 'Better version of ActionSheetPicker with support iOS7 and other improvements.'
-    s.homepage = 'http://skywinder.github.io/ActionSheetPicker-3.0'
-    s.license = 'BSD'
-    s.authors = {
-        'Petr Korolev' => 'https://github.com/skywinder',
-        'Tim Cinel' => 'email@timcinel.com',
-    }
-    s.source = { :git => 'https://github.com/skywinder/ActionSheetPicker-3.0.git', :tag => "#{s.version}" }
-     s.screenshots   = [ "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/date.png",
+#
+#  Be sure to run `pod spec lint Peanut.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see https://guides.cocoapods.org/syntax/podspec.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |spec|
+
+  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  These will help people to find your library, and whilst it
+  #  can feel like a chore to fill in it's definitely to your advantage. The
+  #  summary should be tweet-length, and the description more in depth.
+  #
+
+    spec.name = 'ActionSheetPicker-3.0'
+    spec.version = '2.4.0'
+    spec.summary = 'Easily present an ActionSheet with a PickerView, allowing the user to select from a number of immutable options.'
+
+  # This description is used to generate tags and improve search results.
+  #   * Think: What does it do? Why did you write it? What is the focus?
+  #   * Try to keep it short, snappy and to the point.
+  #   * Write the description between the DESC delimiters below.
+  #   * Finally, don't worry about the indent, CocoaPods strips it!
+  spec.description  = <<-DESC
+ Better version of ActionSheetPicker with support iOS7 and other improvements:
+   - Spawn pickers with convenience function - delegate or reference not required. Just provide a target/action callback.
+   - Add buttons to UIToolbar for quick selection (see ActionSheetDatePicker below)
+   - Delegate protocol available for more control
+   - Universal (iPhone/iPod/iPad)
+  DESC
+
+    spec.homepage = 'https://github.com/skywinder/ActionSheetPicker-3.0'
+    spec.screenshots   = [ "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/date.png",
                         "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/distance.png",
                         "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/ipad.png",
                         "http://skywinder.github.io/ActionSheetPicker-3.0/Screenshots/string.png"]
-    s.requires_arc = true
-    s.platform = :ios, '6.1'
-    s.public_header_files = 'ActionSheetPicker.h', 'Pickers/*.h'
-    s.source_files = 'ActionSheetPicker.h', 'Pickers/*.{h,m}'
-    s.framework = 'UIKit'
+
+
+  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Licensing your code is important. See https://choosealicense.com for more info.
+  #  CocoaPods will detect a license file if there is a named LICENSE*
+  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
+  #
+
+    spec.license = 'BSD'
+
+
+  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the authors of the library, with email addresses. Email addresses
+  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
+  #  accepts just a name if you'd rather not provide an email address.
+  #
+  #  Specify a social_media_url where others can refer to, for example a twitter
+  #  profile URL.
+  #
+
+    spec.authors = {
+        'Petr Korolev' => 'https://github.com/skywinder',
+        'Tim Cinel' => 'email@timcinel.com'
+    }
+
+   spec.social_media_url   = "https://twitter.com/skywinder/"
+
+  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If this Pod runs only on iOS or OS X, then specify the platform and
+  #  the deployment target. You can optionally include the target after the platform.
+  #
+
+   spec.platform     = :ios, "5.0"
+
+  #  When using multiple platforms
+  # spec.ios.deployment_target = "5.0"
+  # spec.osx.deployment_target = "10.7"
+  # spec.watchos.deployment_target = "2.0"
+  # spec.tvos.deployment_target = "9.0"
+
+
+  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the location from where the source should be retrieved.
+  #  Supports git, hg, bzr, svn and HTTP.
+  #
+
+
+    spec.source = { :git => 'https://github.com/skywinder/ActionSheetPicker-3.0.git', :tag => "#{spec.version}" }
+
+
+  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  CocoaPods is smart about how it includes source code. For source files
+  #  giving a folder will include any swift, h, m, mm, c & cpp files.
+  #  For header files it will include any header in the folder.
+  #  Not including the public_header_files will make all headers public.
+  #
+
+  spec.source_files = 'ActionSheetPicker.h', 'Pickers/*.{h,m}'
+  spec.public_header_files = 'ActionSheetPicker.h', 'Pickers/*.h'
+
+
+  # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  A list of resources included with the Pod. These are copied into the
+  #  target bundle with a build phase script. Anything else will be cleaned.
+  #  You can preserve files from being cleaned, please don't preserve
+  #  non-essential files like tests, examples and documentation.
+  #
+
+  # spec.resource  = "icon.png"
+  # spec.resources = "Resources/*.png"
+
+  # spec.preserve_paths = "FilesToSave", "MoreFilesToSave"
+
+
+  # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Link your library with frameworks, or libraries. Libraries do not include
+  #  the lib prefix of their name.
+  #
+
+  
+    spec.framework = 'UIKit'
+  # spec.frameworks = "SomeFramework", "AnotherFramework"
+
+  # spec.library   = "iconv"
+  # spec.libraries = "iconv", "xml2"
+
+
+  # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If your library depends on compiler flags you can set them in the xcconfig hash
+  #  where they will only apply to your library. If you depend on other Podspecs
+  #  you can include multiple dependencies to ensure it works.
+
+   spec.requires_arc = true
+
+  # spec.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
+  # spec.dependency "JSONKit", "~> 1.4"
+
 end


### PR DESCRIPTION
[`deployment_target`](https://guides.cocoapods.org/syntax/podspec.html#deployment_target) is in conflict with `platform`,  and `deployment_target` will be ignored if there is `platform`. Because no version specified in `s.platform = :ios`, then the "iOS Deployment Target" setting of the CocoaPods generated target will be `4.3` which is the default value via CocoaPods.

Fixes #454