### PR TITLE
iOS 14 default datePickerStyle = wheels when not set in the app

### DIFF
--- a/Example Projects/Swift-Example/Swift-Example/ViewControllers/SWTableViewController.swift
+++ b/Example Projects/Swift-Example/Swift-Example/ViewControllers/SWTableViewController.swift
@@ -96,7 +96,7 @@ class SWTableViewController: UITableViewController, UITextFieldDelegate {
 
     @IBAction func dateAndTimePickerClicked(_ sender: UIButton) {
         // example of datetime picker with step interval set to 20 min
-        let datePicker = ActionSheetDatePicker(title: "DateTime with 20min intervals - (Automatic):",
+        let datePicker = ActionSheetDatePicker(title: "DateTime with 20min intervals - (Default):",
                                                datePickerMode: UIDatePicker.Mode.dateAndTime,
                                                selectedDate: Date(),
                                                doneBlock: { picker, date, origin in
@@ -110,10 +110,6 @@ class SWTableViewController: UITableViewController, UITextFieldDelegate {
                                                },
                                                origin: sender.superview!.superview)
         datePicker?.minuteInterval = 20
-        if #available(iOS 13.4, *) {
-            datePicker?.datePickerStyle = .automatic
-        }
-
         datePicker?.show()
     }
 

--- a/Pickers/AbstractActionSheetPicker.m
+++ b/Pickers/AbstractActionSheetPicker.m
@@ -26,6 +26,7 @@
 //
 
 #import "AbstractActionSheetPicker.h"
+#import "ActionSheetDatePicker.h"
 #import "SWActionSheet.h"
 #import <objc/message.h>
 #import <sys/utsname.h>
@@ -243,7 +244,15 @@ CG_INLINE BOOL isIPhone4() {
 #pragma mark - Actions
 
 - (void)showActionSheetPicker {
-    UIView *masterView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.viewSize.width, 260)];
+    CGFloat height = 216.0;
+    if (@available(iOS 14.0, *)) {
+        if ([self isKindOfClass:[ActionSheetDatePicker class]]) {
+            ActionSheetDatePicker *datePicker = (ActionSheetDatePicker *)self;
+            /// To fixed datePickerStyle = inline height issue
+            height = [datePicker getDatePickerHeight];
+        }
+    }
+    UIView *masterView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.viewSize.width, height)];
 
     // to fix bug, appeared only on iPhone 4 Device: https://github.com/skywinder/ActionSheetPicker-3.0/issues/5
     if (isIPhone4()) {

--- a/Pickers/ActionSheetDatePicker.h
+++ b/Pickers/ActionSheetDatePicker.h
@@ -108,4 +108,6 @@ typedef void(^ActionDateCancelBlock)(ActionSheetDatePicker *picker);
 
 - (void)eventForDatePicker:(id)sender;
 
+- (CGFloat)getDatePickerHeight;
+
 @end

--- a/Pickers/ActionSheetDatePicker.m
+++ b/Pickers/ActionSheetDatePicker.m
@@ -290,4 +290,27 @@
     }
 }
 
+- (CGFloat)getDatePickerHeight
+{
+    CGFloat height = 216.0;
+    if (@available(iOS 14.0, *)) {
+        if (_datePickerStyle == UIDatePickerStyleCompact) {
+            height = 90.0;
+        } else if (_datePickerStyle == UIDatePickerStyleInline) {
+            switch (_datePickerMode) {
+                case UIDatePickerModeDate:
+                    height = 350.0;
+                    break;
+                case UIDatePickerModeTime:
+                    height = 90.0;
+                    break;
+                default: // UIDatePickerModeDateAndTime
+                    height = 400.0;
+                    break;
+            }
+        }
+    }
+    return height;
+}
+
 @end

--- a/Pickers/ActionSheetDatePicker.m
+++ b/Pickers/ActionSheetDatePicker.m
@@ -38,6 +38,17 @@
 
 @implementation ActionSheetDatePicker
 
+@synthesize datePickerStyle = _datePickerStyle;
+
+
+-(UIDatePickerStyle)datePickerStyle {
+    if (_datePickerStyle != UIDatePickerStyleAutomatic) {
+        return _datePickerStyle;
+    } else {
+        return UIDatePickerStyleWheels;
+    }
+}
+
 + (instancetype)showPickerWithTitle:(NSString *)title
            datePickerMode:(UIDatePickerMode)datePickerMode selectedDate:(NSDate *)selectedDate
                    target:(id)target action:(SEL)action origin:(id)origin {

--- a/Pickers/SWActionSheet.m
+++ b/Pickers/SWActionSheet.m
@@ -9,12 +9,15 @@ static const float delay = 0.f;
 
 static const float duration = .25f;
 
+static const int sheetBackgroundTag = 101;
+
 static const enum UIViewAnimationOptions options = UIViewAnimationOptionCurveEaseIn;
 
 
-@interface SWActionSheetVC : UIViewController
+@interface SWActionSheetVC : UIViewController <UIGestureRecognizerDelegate>
 
 @property (nonatomic, retain) SWActionSheet *actionSheet;
+@property (nonatomic, retain) UITapGestureRecognizer *dismissTap;
 
 @end
 
@@ -123,9 +126,11 @@ static const enum UIViewAnimationOptions options = UIViewAnimationOptionCurveEas
     if ((self = [super init]))
     {
         view = aView;
+        view.tag = sheetBackgroundTag;
         _windowLevel = windowLevel;
         self.backgroundColor = [UIColor colorWithWhite:0.f alpha:0.0f];
         _bgView = [UIView new];
+        _bgView.tag = sheetBackgroundTag;
 
 // Support iOS 13 Dark Mode - support dynamic background color in iOS 13
 #if defined(__IPHONE_13_0)
@@ -188,6 +193,11 @@ static const enum UIViewAnimationOptions options = UIViewAnimationOptionCurveEas
     self.presented = YES;
 }
 
+- (void)dismissActionSheet
+{
+    [self dismissWithClickedButtonIndex:0 animated:YES];
+}
+
 @end
 
 
@@ -229,12 +239,33 @@ static const enum UIViewAnimationOptions options = UIViewAnimationOptionCurveEas
         _actionSheet.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         [self.view addSubview:_actionSheet];
         [_actionSheet showInContainerViewAnimated:animated];
+
+        // Add Tap Gesture on Background to dismiss ActionSheet
+        [_actionSheet removeGestureRecognizer:self.dismissTap];
+        self.dismissTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissActionSheet)];
+        self.dismissTap.delegate = self;
+        [_actionSheet addGestureRecognizer:self.dismissTap];
     }
 }
 
-- (BOOL)prefersStatusBarHidden {
+- (void)dismissActionSheet
+{
+    [_actionSheet dismissWithClickedButtonIndex:0 animated:YES];
+}
+
+- (BOOL)prefersStatusBarHidden
+{
 	return [UIApplication sharedApplication].statusBarHidden;
 }
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
+{
+    if (touch.view.tag == sheetBackgroundTag) {
+        return NO;
+    }
+    return YES;
+}
+
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_6_0
 // iOS6 support


### PR DESCRIPTION
- iOS 14 default datePickerStyle = wheels 
- Added background tap gesture to dismiss picker view - [Background tap issue](https://github.com/skywinder/ActionSheetPicker-3.0/issues/491)
- Dynamic Height for DatePickerStyle-Inline only (iOS 14.0 specific)

<img width="400" alt="Screenshot 2020-09-24 at 2 05 06 PM" src="https://user-images.githubusercontent.com/6180345/94140168-e3881400-fe7b-11ea-9d5b-ea90bdf9826a.png">
<img width="400" alt="Screenshot 2020-09-24 at 3 38 05 PM" src="https://user-images.githubusercontent.com/6180345/94140217-f4d12080-fe7b-11ea-891f-db35fe161fb2.png">
<img width="400" alt="Screenshot 2020-09-24 at 9 14 09 PM" src="https://user-images.githubusercontent.com/6180345/94178336-03373080-feac-11ea-9383-dd3638a793e1.png">


<img width="400" alt="Screenshot 2020-09-24 at 3 52 40 PM" src="https://user-images.githubusercontent.com/6180345/94141601-087d8680-fe7e-11ea-8a5b-d6eb4d37bf74.png">
<img width="400" alt="Screenshot 2020-09-24 at 3 52 47 PM" src="https://user-images.githubusercontent.com/6180345/94141608-0ca9a400-fe7e-11ea-8761-7d9e653eea9c.png">
