### PR TITLE
Issue #505: iOS 14 unable to select date in inline datePickerStyle

### DIFF
--- a/Pickers/SWActionSheet.m
+++ b/Pickers/SWActionSheet.m
@@ -260,7 +260,8 @@ static const enum UIViewAnimationOptions options = UIViewAnimationOptionCurveEas
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
 {
-    if (touch.view.tag == sheetBackgroundTag) {
+    CGPoint location = [touch locationInView:_actionSheet];
+    if (CGRectContainsPoint(_actionSheet.bgView.frame, location)) {
         return NO;
     }
     return YES;

--- a/Pickers/SWActionSheet.m
+++ b/Pickers/SWActionSheet.m
@@ -257,10 +257,7 @@ static const enum UIViewAnimationOptions options = UIViewAnimationOptionCurveEas
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
 {
     CGPoint location = [touch locationInView:_actionSheet];
-    if (CGRectContainsPoint(_actionSheet.bgView.frame, location)) {
-        return NO;
-    }
-    return YES;
+    return !CGRectContainsPoint(_actionSheet.bgView.frame, location);
 }
 
 

--- a/Pickers/SWActionSheet.m
+++ b/Pickers/SWActionSheet.m
@@ -9,8 +9,6 @@ static const float delay = 0.f;
 
 static const float duration = .25f;
 
-static const int sheetBackgroundTag = 101;
-
 static const enum UIViewAnimationOptions options = UIViewAnimationOptionCurveEaseIn;
 
 
@@ -126,11 +124,9 @@ static const enum UIViewAnimationOptions options = UIViewAnimationOptionCurveEas
     if ((self = [super init]))
     {
         view = aView;
-        view.tag = sheetBackgroundTag;
         _windowLevel = windowLevel;
         self.backgroundColor = [UIColor colorWithWhite:0.f alpha:0.0f];
         _bgView = [UIView new];
-        _bgView.tag = sheetBackgroundTag;
 
 // Support iOS 13 Dark Mode - support dynamic background color in iOS 13
 #if defined(__IPHONE_13_0)


### PR DESCRIPTION
This solution works, but there's a small caveat. In iPhone X style phones,
the notch corners wont trigger the dismiss action. Otherwise it works as
expected.