### PR TITLE
Fixed #526 (`tapDismissAction` broken after 2.5.1), Improved #491 (Background-tap to dismiss)

### DIFF
--- a/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/AbstractActionSheetPicker.h
+++ b/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/AbstractActionSheetPicker.h
@@ -45,7 +45,7 @@ typedef NS_ENUM(NSInteger, ActionType) {
 };
 
 typedef NS_ENUM(NSInteger, TapAction) {
-    TapActionNone,
+    TapActionDismiss,
     TapActionSuccess,
     TapActionCancel
 };
@@ -81,7 +81,7 @@ static NSString *const kActionTarget = @"buttonActionTarget";
 @property(nonatomic) NSNumber *pickerBlurRadius;
 @property(nonatomic, retain) Class popoverBackgroundViewClass; //allow popover customization on iPad
 @property(nonatomic) UIInterfaceOrientationMask supportedInterfaceOrientations; // You can set your own supportedInterfaceOrientations value to prevent dismissing picker in some special cases.
-@property(nonatomic) TapAction tapDismissAction; // Specify, which action should be fired in case of tapping outside of the picker (on top darkened side). Default is TapActionNone.
+@property(nonatomic) TapAction tapDismissAction; // Specify, which action should be fired in case of tapping outside of the picker (on top darkened side). Default is TapActionDismiss.
 @property(nonatomic) BOOL popoverDisabled; // Disable popover behavior on iPad
 
 

--- a/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/AbstractActionSheetPicker.m
+++ b/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/AbstractActionSheetPicker.m
@@ -144,7 +144,7 @@ CG_INLINE BOOL isIPhone4() {
         [self setCancelBarButtonItem:sysCancelButton];
         [self setDoneBarButtonItem:sysDoneButton];
 
-        self.tapDismissAction = TapActionNone;
+        self.tapDismissAction = TapActionDismiss;
         //allows us to use this without needing to store a reference in calling class
         self.selfReference = self;
 
@@ -291,10 +291,16 @@ CG_INLINE BOOL isIPhone4() {
 #pragma ide diagnostic ignored "UnavailableInDeploymentTarget"
     {
         switch (self.tapDismissAction) {
-            case TapActionNone:
-                break;
-            case TapActionSuccess: {
+            case TapActionDismiss: {
                 // add tap dismiss action
+                self.actionSheet.window.userInteractionEnabled = YES;
+                UITapGestureRecognizer *tapAction = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissPicker)];
+                tapAction.delegate = self;
+                [self.actionSheet.window addGestureRecognizer:tapAction];
+                break;
+            }
+            case TapActionSuccess: {
+                // add tap success action with dismissPicker
                 self.actionSheet.window.userInteractionEnabled = YES;
                 UITapGestureRecognizer *tapAction = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(actionPickerDone:)];
                 tapAction.delegate = self;
@@ -302,7 +308,7 @@ CG_INLINE BOOL isIPhone4() {
                 break;
             }
             case TapActionCancel: {
-                // add tap dismiss action
+                // add tap cancel action with dismissPicker
                 self.actionSheet.window.userInteractionEnabled = YES;
                 UITapGestureRecognizer *tapAction = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(actionPickerCancel:)];
                 tapAction.delegate = self;

--- a/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/SWActionSheet.m
+++ b/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/SWActionSheet.m
@@ -12,10 +12,9 @@ static const float duration = .25f;
 static const enum UIViewAnimationOptions options = UIViewAnimationOptionCurveEaseIn;
 
 
-@interface SWActionSheetVC : UIViewController <UIGestureRecognizerDelegate>
+@interface SWActionSheetVC : UIViewController
 
 @property (nonatomic, retain) SWActionSheet *actionSheet;
-@property (nonatomic, retain) UITapGestureRecognizer *dismissTap;
 
 @end
 
@@ -189,11 +188,6 @@ static const enum UIViewAnimationOptions options = UIViewAnimationOptionCurveEas
     self.presented = YES;
 }
 
-- (void)dismissActionSheet
-{
-    [self dismissWithClickedButtonIndex:0 animated:YES];
-}
-
 @end
 
 
@@ -235,29 +229,12 @@ static const enum UIViewAnimationOptions options = UIViewAnimationOptionCurveEas
         _actionSheet.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         [self.view addSubview:_actionSheet];
         [_actionSheet showInContainerViewAnimated:animated];
-
-        // Add Tap Gesture on Background to dismiss ActionSheet
-        [_actionSheet removeGestureRecognizer:self.dismissTap];
-        self.dismissTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissActionSheet)];
-        self.dismissTap.delegate = self;
-        [_actionSheet addGestureRecognizer:self.dismissTap];
     }
-}
-
-- (void)dismissActionSheet
-{
-    [_actionSheet dismissWithClickedButtonIndex:0 animated:YES];
 }
 
 - (BOOL)prefersStatusBarHidden
 {
 	return [UIApplication sharedApplication].statusBarHidden;
-}
-
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
-{
-    CGPoint location = [touch locationInView:_actionSheet];
-    return !CGRectContainsPoint(_actionSheet.bgView.frame, location);
 }
 
 - (BOOL)shouldAutorotate

--- a/Example Projects/Swift-Example/Swift-Example/ViewControllers/SWTableViewController.swift
+++ b/Example Projects/Swift-Example/Swift-Example/ViewControllers/SWTableViewController.swift
@@ -46,27 +46,26 @@ class SWTableViewController: UITableViewController, UITextFieldDelegate {
                                     origin: sender.superview!.superview)
     }
 
-
     @IBAction func timePickerClicked(_ sender: UIButton) {
         // example of picker initialized with target/action parameters
-        let datePicker = ActionSheetDatePicker(title: "Time - (Automatic):",
-                                               datePickerMode: UIDatePicker.Mode.time,
-                                               selectedDate: Date(),
-                                               target: self,
-                                               action: #selector(datePicked(_:)),
-                                               origin: sender.superview!.superview)
+        let datePicker = ActionSheetDatePicker(
+                    title: "Time - (Automatic):",
+                    datePickerMode: .time,
+                    selectedDate: Date(),
+                    doneBlock: { (datePicker, selectedDate, origin) in
+                        print("DONE: Date picked \(selectedDate ?? "NO DATE")")
+                    },
+                    cancel: { (datePicker) in
+                        print("CANCELLED")
+                    },
+                    origin: sender.superview!.superview)
         datePicker?.minuteInterval = 20
         if #available(iOS 13.4, *) {
             datePicker?.datePickerStyle = .automatic
         }
-
+        datePicker?.tapDismissAction = .cancel
         datePicker?.show()
     }
-
-    @objc func datePicked(_ date: Date) {
-        print("Date picked \(date)")
-    }
-
 
     @IBAction func datePickerClicked(_ sender: UIButton) {
         // example of date picker with min and max values set (as a week in past and week in future from today)


### PR DESCRIPTION
 - Improved background-tap dismiss action of sheet using `TapActionDismiss` ([#491 - Background tap issue](https://github.com/skywinder/ActionSheetPicker-3.0/issues/491))
 - Fixed `tapDismissAction` broken after 2.5.1 (#526)