### PR TITLE
[Issue 534] Fixed compact datePickerStyle issue on iOS 14.4 & above

### DIFF
--- a/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/ActionSheetDatePicker.m
+++ b/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/ActionSheetDatePicker.m
@@ -296,7 +296,7 @@
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000 // Xcode 12 and iOS 14, or greater
     if (@available(iOS 14.0, *)) {
         if (_datePickerStyle == UIDatePickerStyleCompact) {
-            height = 90.0;
+            height = 250.0;
         } else if (_datePickerStyle == UIDatePickerStyleInline) {
             switch (_datePickerMode) {
                 case UIDatePickerModeDate:

--- a/Example Projects/Swift-Example/Swift-Example/ViewControllers/SWTableViewController.swift
+++ b/Example Projects/Swift-Example/Swift-Example/ViewControllers/SWTableViewController.swift
@@ -69,7 +69,7 @@ class SWTableViewController: UITableViewController, UITextFieldDelegate {
 
     @IBAction func datePickerClicked(_ sender: UIButton) {
         // example of date picker with min and max values set (as a week in past and week in future from today)
-        let datePicker = ActionSheetDatePicker(title: "Date within 2 weeks - (Inline):",
+        let datePicker = ActionSheetDatePicker(title: "Date within 2 weeks - (Compact):",
                                                datePickerMode: UIDatePicker.Mode.date,
                                                selectedDate: Date(),
                                                doneBlock: { picker, date, origin in
@@ -86,7 +86,7 @@ class SWTableViewController: UITableViewController, UITextFieldDelegate {
         datePicker?.minimumDate = Date(timeInterval: -secondsInWeek, since: Date())
         datePicker?.maximumDate = Date(timeInterval: secondsInWeek, since: Date())
         if #available(iOS 14.0, *) {
-            datePicker?.datePickerStyle = .inline
+            datePicker?.datePickerStyle = .compact
         }
 
         datePicker?.show()


### PR DESCRIPTION
[Issue #534 ] Fixed `compact` datePickerStyle issue on iOS 14.4 & above

<img width="535" alt="Screen Shot 2021-09-19 at 5 39 16 PM" src="https://user-images.githubusercontent.com/6180345/133929752-ccec85d5-6f9d-4a9f-a2d2-423dad51d4fb.png">
<img width="535" alt="Screen Shot 2021-09-19 at 5 39 28 PM" src="https://user-images.githubusercontent.com/6180345/133929757-d323bcff-0576-4202-95f8-74c1a8561218.png">
