### PR TITLE
Fixes issue with SPM imports

### DIFF
--- a/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/AbstractActionSheetPicker.m
+++ b/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/AbstractActionSheetPicker.m
@@ -798,8 +798,9 @@ CG_INLINE BOOL isIPhone4() {
 #pragma mark UIGestureRecognizerDelegate
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
-    CGPoint location = [gestureRecognizer locationInView:self.toolbar];
-    return !CGRectContainsPoint(self.toolbar.bounds, location);
+    CGPoint toolbarLocation = [gestureRecognizer locationInView:self.toolbar];
+    CGPoint actionSheetLocation = [gestureRecognizer locationInView:self.actionSheet];
+    return !(CGRectContainsPoint(self.toolbar.bounds, toolbarLocation) || CGRectContainsPoint(self.actionSheet.bgView.frame, actionSheetLocation));
 }
 
 @end

--- a/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/include/ActionSheetCustomPicker.h
+++ b/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/include/ActionSheetCustomPicker.h
@@ -10,8 +10,8 @@
 #import <AbstractActionSheetPicker.h>
 #import <ActionSheetCustomPickerDelegate.h>
 #else
-#import <CoreActionSheetPicker/AbstractActionSheetPicker.h>
-#import <CoreActionSheetPicker/ActionSheetCustomPickerDelegate.h>
+#import "AbstractActionSheetPicker.h"
+#import "ActionSheetCustomPickerDelegate.h"
 #endif
 
 @interface ActionSheetCustomPicker : AbstractActionSheetPicker

--- a/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/include/ActionSheetCustomPickerDelegate.h
+++ b/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/include/ActionSheetCustomPickerDelegate.h
@@ -10,7 +10,7 @@
 #if COCOAPODS
 #import <AbstractActionSheetPicker.h>
 #else
-#import <CoreActionSheetPicker/AbstractActionSheetPicker.h>
+#import "AbstractActionSheetPicker.h"
 #endif
 
 @protocol ActionSheetCustomPickerDelegate <UIPickerViewDelegate, UIPickerViewDataSource>

--- a/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/include/ActionSheetDatePicker.h
+++ b/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/include/ActionSheetDatePicker.h
@@ -28,7 +28,7 @@
 #if COCOAPODS
 #import <AbstractActionSheetPicker.h>
 #else
-#import <CoreActionSheetPicker/AbstractActionSheetPicker.h>
+#import "AbstractActionSheetPicker.h"
 #endif
 
 @class ActionSheetDatePicker;

--- a/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/include/ActionSheetDistancePicker.h
+++ b/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/include/ActionSheetDistancePicker.h
@@ -29,8 +29,8 @@
 #import <AbstractActionSheetPicker.h>
 #import <DistancePickerView.h>
 #else
-#import <CoreActionSheetPicker/AbstractActionSheetPicker.h>
-#import <CoreActionSheetPicker/DistancePickerView.h>
+#import "AbstractActionSheetPicker.h"
+#import "DistancePickerView.h"
 #endif
 
 @interface ActionSheetDistancePicker : AbstractActionSheetPicker <UIPickerViewDelegate, UIPickerViewDataSource>

--- a/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/include/ActionSheetLocalePicker.h
+++ b/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/include/ActionSheetLocalePicker.h
@@ -28,7 +28,7 @@
 #if COCOAPODS
 #import <AbstractActionSheetPicker.h>
 #else
-#import <CoreActionSheetPicker/AbstractActionSheetPicker.h>
+#import "AbstractActionSheetPicker.h"
 #endif
 
 @class ActionSheetLocalePicker;

--- a/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/include/ActionSheetMultipleStringPicker.h
+++ b/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/include/ActionSheetMultipleStringPicker.h
@@ -31,7 +31,7 @@
 #if COCOAPODS
 #import <AbstractActionSheetPicker.h>
 #else
-#import <CoreActionSheetPicker/AbstractActionSheetPicker.h>
+#import "AbstractActionSheetPicker.h"
 #endif
 
 @class ActionSheetMultipleStringPicker;

--- a/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/include/ActionSheetStringPicker.h
+++ b/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/include/ActionSheetStringPicker.h
@@ -28,7 +28,7 @@
 #if COCOAPODS
 #import <AbstractActionSheetPicker.h>
 #else
-#import <CoreActionSheetPicker/AbstractActionSheetPicker.h>
+#import "AbstractActionSheetPicker.h"
 #endif
 
 @class ActionSheetStringPicker;


### PR DESCRIPTION
Hey,

The following PR should fix the SPM imports that were requiring a module named `<ActionSheetPicker/someheader.h>` instead of just referencing the same module.