### PR TITLE
Fix iOS 26 crashes and layout issues (#591, #587, #590, #579)

### DIFF
--- a/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/AbstractActionSheetPicker.m
+++ b/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/AbstractActionSheetPicker.m
@@ -230,6 +230,11 @@ CG_INLINE BOOL isIPhone4() {
 #pragma mark - Actions
 
 - (void)showActionSheetPicker {
+    // Each presentation gets a fresh retry budget for addTapDismissAction,
+    // otherwise re-showing the same picker accumulates the count until it
+    // permanently hits the cap.
+    self.windowTapActionRetryCount = 0;
+
     CGFloat height = 216.0;
     if (@available(iOS 14.0, *)) {
         if ([self isKindOfClass:[ActionSheetDatePicker class]]) {
@@ -239,6 +244,10 @@ CG_INLINE BOOL isIPhone4() {
         }
     }
     
+    if (@available(iOS 26.0, *)) {
+        height += 16.0; // extra top padding for the iOS 26 toolbar inset, see #590
+    }
+
     /// Bottom padding for iPhone X style phones (adds some additional height for the home bar).
     if (@available(iOS 11.0, *)) {
         UIWindow *window = UIApplication.sharedApplication.keyWindow;
@@ -276,8 +285,14 @@ CG_INLINE BOOL isIPhone4() {
     
     // Centers the pickerView frame in cases where the pickerView is not as wide as masterView
     CGFloat xOffset = (CGRectGetWidth(masterView.frame) - CGRectGetWidth(self.pickerView.frame)) / 2;
+    CGFloat yOffset = CGRectGetMinY(self.pickerView.frame);
+    if (@available(iOS 26.0, *)) {
+        if (!self.toolbar.hidden) {
+            yOffset += 8.0; // keep clear of the inset toolbar, see #590
+        }
+    }
     self.pickerView.frame = CGRectMake(xOffset,
-                                       CGRectGetMinY(self.pickerView.frame),
+                                       yOffset,
                                        CGRectGetWidth(self.pickerView.frame),
                                        CGRectGetHeight(self.pickerView.frame));
     
@@ -301,6 +316,8 @@ CG_INLINE BOOL isIPhone4() {
 	}
 	if (self.windowTapActionRetryCount > 10) {
 		NSAssert(NO, @"Failed to find Picker view's window. This may cause a memory leak.");
+		// Bail out in release builds too, otherwise the dispatch_async below retries forever.
+		return;
 	}
 	if (!self.pickerView.window) {
 		self.windowTapActionRetryCount += 1;
@@ -313,7 +330,7 @@ CG_INLINE BOOL isIPhone4() {
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "UnavailableInDeploymentTarget"
     {
-		SEL sel;
+		SEL sel = NULL;
         switch (self.tapDismissAction) {
             case TapActionDismiss:
                 // add tap dismiss action
@@ -500,7 +517,11 @@ CG_INLINE BOOL isIPhone4() {
 
 
 - (UIToolbar *)createPickerToolbarWithTitle:(NSString *)title {
-    CGRect frame = CGRectMake(0, 0, self.viewSize.width, 44);
+    CGFloat toolbarTop = 0;
+    if (@available(iOS 26.0, *)) {
+        toolbarTop = 16; // inset from the sheet top, see #590
+    }
+    CGRect frame = CGRectMake(0, toolbarTop, self.viewSize.width, 44);
     UIToolbar *pickerToolbar = [[UIToolbar alloc] initWithFrame:frame];
     pickerToolbar.barStyle = UIBarStyleDefault;
 
@@ -532,6 +553,14 @@ CG_INLINE BOOL isIPhone4() {
         UIBarButtonItem *labelButton;
 
         labelButton = [self createToolbarLabelWithTitle:title titleTextAttributes:self.titleTextAttributes andAttributedTitle:self.attributedTitle];
+
+        if (@available(iOS 26.0, *)) {
+            // Drop the Liquid Glass background behind the title label (#590).
+            // Set via KVC so this still compiles with pre-26 SDKs.
+            if ([labelButton respondsToSelector:NSSelectorFromString(@"setHidesSharedBackground:")]) {
+                [labelButton setValue:@(YES) forKey:@"hidesSharedBackground"];
+            }
+        }
 
         [barItems addObject:labelButton];
         [barItems addObject:flexSpace];

--- a/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/SWActionSheet.m
+++ b/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/SWActionSheet.m
@@ -92,9 +92,32 @@ static const enum UIViewAnimationOptions options = UIViewAnimationOptionCurveEas
 // Handle UIWindow for iOS 13 changes
 #if defined(__IPHONE_13_0)
         if (@available(iOS 13.0, *)) {
-            UIScene *scene = [UIApplication sharedApplication].connectedScenes.allObjects.firstObject;
-            if (scene && [scene isKindOfClass:[UIWindowScene class]]) {
-                UIWindowScene *windowScene = (UIWindowScene *)scene;
+            // Pick a foreground-active application scene. Taking connectedScenes.firstObject
+            // can return an external-display scene (screen mirroring, #587) or leave the
+            // window sceneless, whose trait collection lacks an idiom and crashes UIKit on
+            // iOS 26 (#591).
+            UIWindowScene *windowScene = nil;
+            UIWindowScene *fallbackScene = nil;
+            for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+                if (![scene isKindOfClass:[UIWindowScene class]])
+                    continue;
+                if (![scene.session.role isEqualToString:UIWindowSceneSessionRoleApplication]) {
+                    if (!fallbackScene)
+                        fallbackScene = (UIWindowScene *)scene;
+                    continue;
+                }
+                if (scene.activationState == UISceneActivationStateForegroundActive) {
+                    windowScene = (UIWindowScene *)scene;
+                    break;
+                }
+                if (!windowScene)
+                    windowScene = (UIWindowScene *)scene;
+            }
+            // Any window scene still beats a sceneless window, whose trait
+            // collection lacks an idiom and crashes UIKit on iOS 26 (#591).
+            if (!windowScene)
+                windowScene = fallbackScene;
+            if (windowScene) {
                 window = [[UIWindow alloc] initWithWindowScene:windowScene];
             }
         }

--- a/CoreActionSheetPicker/CoreActionSheetPickerTests/CoreActionSheetPickerTests.m
+++ b/CoreActionSheetPicker/CoreActionSheetPickerTests/CoreActionSheetPickerTests.m
@@ -8,33 +8,123 @@
 
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
+#import "ActionSheetStringPicker.h"
+
+// Expose the private toolbar factory for geometry assertions.
+@interface AbstractActionSheetPicker (TestingHooks)
+- (UIToolbar *)createPickerToolbarWithTitle:(NSString *)aTitle;
+@end
+
+// Subclass that presents with a hidden toolbar, to cover the
+// toolbar.hidden layout branch in showActionSheetPicker.
+@interface HiddenToolbarStringPicker : ActionSheetStringPicker
+@end
+
+@implementation HiddenToolbarStringPicker
+- (UIToolbar *)createPickerToolbarWithTitle:(NSString *)aTitle {
+    UIToolbar *toolbar = [super createPickerToolbarWithTitle:aTitle];
+    toolbar.hidden = YES;
+    return toolbar;
+}
+@end
 
 @interface CoreActionSheetPickerTests : XCTestCase
-
+@property (nonatomic, strong) UIView *origin;
 @end
 
 @implementation CoreActionSheetPickerTests
 
 - (void)setUp {
     [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
+    self.origin = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)];
 }
 
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
+- (CGFloat)expectedToolbarTopInset {
+    if (@available(iOS 26.0, *)) {
+        return 16.0;
+    }
+    return 0.0;
 }
 
-- (void)testExample {
-    // This is an example of a functional test case.
-    XCTAssert(YES, @"Pass");
+- (ActionSheetStringPicker *)makePicker {
+    return [[ActionSheetStringPicker alloc] initWithTitle:@"Title"
+                                                     rows:@[@"a", @"b", @"c"]
+                                         initialSelection:0
+                                                doneBlock:nil
+                                              cancelBlock:nil
+                                                   origin:self.origin];
 }
 
-- (void)testPerformanceExample {
-    // This is an example of a performance test case.
-    [self measureBlock:^{
-        // Put the code you want to measure the time of here.
-    }];
+#pragma mark - Toolbar inset (#590)
+
+- (void)testToolbarTopInsetMatchesOSVersion {
+    ActionSheetStringPicker *picker = [self makePicker];
+    UIToolbar *toolbar = [picker createPickerToolbarWithTitle:@"Title"];
+    XCTAssertEqualWithAccuracy(toolbar.frame.origin.y, [self expectedToolbarTopInset], 0.01);
+    XCTAssertEqualWithAccuracy(toolbar.frame.size.height, 44.0, 0.01);
+}
+
+#pragma mark - Presented sheet geometry (#590)
+
+- (void)testPresentedPickerGeometry {
+    ActionSheetStringPicker *picker = [self makePicker];
+    [picker showActionSheetPicker];
+
+    CGFloat inset = [self expectedToolbarTopInset];
+
+    XCTAssertNotNil(picker.toolbar);
+    XCTAssertEqualWithAccuracy(picker.toolbar.frame.origin.y, inset, 0.01);
+
+    // ActionSheetStringPicker frames its UIPickerView at y=40; on iOS 26 the
+    // base class shifts it 8pt down to clear the inset toolbar.
+    CGFloat expectedPickerY = 40.0 + (inset > 0 ? 8.0 : 0.0);
+    XCTAssertEqualWithAccuracy(picker.pickerView.frame.origin.y, expectedPickerY, 0.01);
+
+    // The sheet container grows by the toolbar inset (safe-area bottom is 0
+    // in a hostless test bundle, keyWindow being nil).
+    UIView *masterView = picker.toolbar.superview;
+    XCTAssertNotNil(masterView);
+    XCTAssertEqualWithAccuracy(masterView.frame.size.height, 216.0 + inset, 0.01);
+
+    [picker hidePickerWithCancelAction];
+}
+
+- (void)testHiddenToolbarSkipsPickerShift {
+    HiddenToolbarStringPicker *picker =
+        [[HiddenToolbarStringPicker alloc] initWithTitle:@"Title"
+                                                    rows:@[@"a", @"b", @"c"]
+                                        initialSelection:0
+                                               doneBlock:nil
+                                             cancelBlock:nil
+                                                  origin:self.origin];
+    [picker showActionSheetPicker];
+
+    // The hidden-toolbar branch repositions the picker to y=halfBorderWidth
+    // (0 by default) inside a fixed 220pt container; the iOS 26 toolbar
+    // shift must not apply because there is no toolbar to keep clear of.
+    XCTAssertEqualWithAccuracy(picker.pickerView.frame.origin.y, 0.0, 0.01);
+
+    UIView *masterView = picker.toolbar.superview;
+    XCTAssertNotNil(masterView);
+    XCTAssertEqualWithAccuracy(masterView.frame.size.height, 220.0, 0.01);
+
+    [picker hidePickerWithCancelAction];
+}
+
+#pragma mark - Tap-dismiss retry budget (#579)
+
+- (void)testRetryCountResetsOnEachShow {
+    ActionSheetStringPicker *picker = [self makePicker];
+    [picker setValue:@99 forKey:@"windowTapActionRetryCount"];
+
+    [picker showActionSheetPicker];
+
+    // showActionSheetPicker resets the budget; addTapDismissAction may have
+    // consumed at most one retry before the window attaches.
+    NSInteger count = [[picker valueForKey:@"windowTapActionRetryCount"] integerValue];
+    XCTAssertLessThanOrEqual(count, 1);
+
+    [picker hidePickerWithCancelAction];
 }
 
 @end


### PR DESCRIPTION
Fixes #591, fixes #587, fixes #590. Related: #579 (suspected root cause; left open pending reporter confirmation).

## What this fixes

- **#591 — iOS 26 crash** `Trait collection does not specify a user interface idiom`: `SWActionSheet` now attaches its window to a foreground-active **application-role** `UIWindowScene` instead of `connectedScenes.firstObject`, with a fallback to any window scene — a sceneless `initWithFrame:` window is what crashes UIKit on iOS 26.
- **#587 — picker shown on the mirrored screen**: same root cause; the role filter skips external-display scenes.
- **#590 — iOS 26 toolbar layout**: adopts @DurgaAchyuth's Option 1 (toolbar inset 16pt, sheet height +16, picker +8) **gated to iOS 26 only** so pre-26 layout is untouched, plus `hidesSharedBackground` on the title label (set via KVC so it compiles with pre-26 SDKs). The +8 shift is additionally skipped when the toolbar is hidden, where it would clip the picker instead.
- **#579 (suspected) — crash/leak around `addTapDismissAction`**: the retry loop previously recursed via `dispatch_async` forever in release builds once the 10-retry cap was exceeded (the `NSAssert` compiles out), leaking `selfReference`. It now bails out, and the retry budget resets on each presentation so a re-shown picker doesn't inherit a stale count.

## Verification

- Geometry regression tests added (`CoreActionSheetPickerTests`) asserting the toolbar inset, picker offset (incl. hidden-toolbar branch), sheet height, and retry-counter reset — passing on both **iOS 18.4** and **iOS 26.4** simulator runtimes, so both `@available` branches are exercised.
- Builds clean with Xcode 26 / SDK 26.5.

## What still needs human eyes

The #590 layout values are the community-tested ones from the issue thread; I'd appreciate visual confirmation on iOS 26 devices from the reporters (asked in the issues). The screen-mirroring scenario (#587) can only be verified on a real device setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
