### PR TITLE
Support custom text color on the wheels date picker

### DIFF
--- a/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/ActionSheetDatePicker.m
+++ b/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/ActionSheetDatePicker.m
@@ -177,12 +177,29 @@
     datePicker.calendar = self.calendar;
     datePicker.timeZone = self.timeZone;
     datePicker.locale = self.locale;
+    BOOL isWheelsStyle = YES; // pre-13.4 only has the wheels look
     if (@available(iOS 13.4, *)) {
         datePicker.preferredDatePickerStyle = self.datePickerStyle;
-    } else {
-        UIColor *textColor = [self.pickerTextAttributes valueForKey:NSForegroundColorAttributeName];
-        if (textColor) {
-            [datePicker setValue:textColor forKey:@"textColor"]; // use ObjC runtime to set value for property that is not exposed publicly
+        isWheelsStyle = (self.datePickerStyle == UIDatePickerStyleWheels);
+    }
+    UIColor *textColor = [self.pickerTextAttributes valueForKey:NSForegroundColorAttributeName];
+    if (@available(iOS 13.0, *)) {
+        // The base class seeds pickerTextAttributes with labelColor; that is
+        // already the picker's default, so only a color the caller actually
+        // chose should be forced onto the wheels.
+        if ([textColor isEqual:[UIColor labelColor]]) {
+            textColor = nil;
+        }
+    }
+    if (textColor && isWheelsStyle) {
+        // The textColor KVC key is private but long-standing on the wheels
+        // view; other styles' views throw on it (e.g.
+        // _UIDatePickerMacCompactView, #484), hence the wheels-only guard and
+        // the @try in case a future iOS removes the key (#324, #582).
+        @try {
+            [datePicker setValue:textColor forKey:@"textColor"];
+        } @catch (NSException *exception) {
+            NSLog(@"ActionSheetDatePicker: setting textColor is not supported on this iOS version: %@", exception.reason);
         }
     }
     

--- a/CoreActionSheetPicker/CoreActionSheetPickerTests/CoreActionSheetPickerTests.m
+++ b/CoreActionSheetPicker/CoreActionSheetPickerTests/CoreActionSheetPickerTests.m
@@ -186,6 +186,47 @@
     }
 }
 
+#pragma mark - Date picker text color (#324 / #582 / #484)
+
+- (void)testSetTextColorAppliesToWheelsDatePicker {
+    if (@available(iOS 13.4, *)) {
+        ActionSheetDatePicker *picker =
+            [[ActionSheetDatePicker alloc] initWithTitle:@"Title"
+                                          datePickerMode:UIDatePickerModeDate
+                                            selectedDate:[NSDate dateWithTimeIntervalSince1970:1767225600]
+                                               doneBlock:nil
+                                             cancelBlock:nil
+                                                  origin:self.origin];
+        picker.datePickerStyle = UIDatePickerStyleWheels;
+        [picker setTextColor:UIColor.redColor];
+        [picker showActionSheetPicker];
+
+        UIColor *applied = [(UIDatePicker *)picker.pickerView valueForKey:@"textColor"];
+        XCTAssertEqualObjects(applied, UIColor.redColor,
+                              @"setTextColor should tint the wheels date picker (#324/#582)");
+
+        [picker hidePickerWithCancelAction];
+    }
+}
+
+- (void)testSetTextColorDoesNotThrowOnCompactStyle {
+    // The textColor KVC key only exists on the wheels view; the compact view
+    // (_UIDatePickerMacCompactView and friends) throws on it (#484).
+    if (@available(iOS 14.0, *)) {
+        ActionSheetDatePicker *picker =
+            [[ActionSheetDatePicker alloc] initWithTitle:@"Title"
+                                          datePickerMode:UIDatePickerModeDate
+                                            selectedDate:[NSDate dateWithTimeIntervalSince1970:1767225600]
+                                               doneBlock:nil
+                                             cancelBlock:nil
+                                                  origin:self.origin];
+        picker.datePickerStyle = UIDatePickerStyleCompact;
+        [picker setTextColor:UIColor.redColor];
+        XCTAssertNoThrow([picker showActionSheetPicker]);
+        [picker hidePickerWithCancelAction];
+    }
+}
+
 #pragma mark - Tap-dismiss retry budget (#579)
 
 - (void)testRetryCountResetsOnEachShow {


### PR DESCRIPTION
Fixes #324, fixes #582, fixes #484.

## Problem

`setTextColor:` worked for the `UIPickerView`-based pickers but never reached `ActionSheetDatePicker` on iOS 13.4+ — the KVC `textColor` application only lived in the pre-13.4 branch, so dark/custom-themed date and time pickers showed default text (#324 from 2017, #582 from 2024). Separately, on Mac Catalyst the KVC key used to hit `_UIDatePickerMacCompactView`, which throws `unrecognized selector` (#484).

## Fix

Apply the caller-chosen text color via the `textColor` KVC key **only for the wheels style** (other styles' internal views throw on the key — that was #484's crash), wrapped in `@try` in case a future iOS removes the key. The base class seeds `labelColor` as a default attribute; that is skipped, so default appearance is byte-identical (verified by the existing snapshot references passing unchanged).

Empirically verified the key still works before relying on it: set + readback and a visual red-wheels capture on both iOS 18.4 and iOS 26.4 simulators.

## Verification

- `testSetTextColorAppliesToWheelsDatePicker` — fails before (stays `labelColor`), passes after (red applied).
- `testSetTextColorDoesNotThrowOnCompactStyle` — regression guard for the #484 crash mode.
- Full unit + snapshot suites green on iOS 18.4 and 26.4; default-appearance snapshots unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)