### PR TITLE
Release 2.8.0

### DIFF
--- a/ActionSheetPicker-3.0.podspec
+++ b/ActionSheetPicker-3.0.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'ActionSheetPicker-3.0'
-  spec.version = '2.7.5'
+  spec.version = '2.8.0'
   spec.summary = 'Easily present an ActionSheet with a PickerView, allowing the user to select from a number of immutable options.'
   spec.description  = <<-DESC
  Better version of ActionSheetPicker with support iOS9 and other improvements:


### PR DESCRIPTION
Bumps the podspec to 2.8.0. Highlights since 2.7.5:

## Fixed
- iOS 26 crash "trait collection does not specify a user interface idiom" — sheet window now attaches to a foreground-active application scene (#591, #593)
- Picker appearing on the mirrored screen during screen mirroring (#587, #593)
- iOS 26 toolbar/title layout (Liquid Glass) (#590, #593)
- Release-build infinite retry/leak in the tap-dismiss setup, retry budget now resets per presentation (#579, #593)
- Compact date picker stretched full-width with its capsule pinned under the Done button (#534, #595)
- Mac Catalyst `_setTextColor` crash protection (#484, #597)

## Changed
- **Behavioral**: `tapDismissAction` now defaults to `.cancel` — tapping outside the sheet fires the cancel callback (#531, #596). Set `.dismiss` explicitly for the old silent behavior.

## Added
- `setTextColor:` now applies to the wheels date/time picker (#324, #582, #597)
- Unit-test suite and snapshot tests (iOS 18/26 references) (#594, #595, #596, #597)

🤖 Generated with [Claude Code](https://claude.com/claude-code)